### PR TITLE
Added Draw Limit to Returned Results

### DIFF
--- a/getLotteryResults.php
+++ b/getLotteryResults.php
@@ -9,6 +9,7 @@
 // 2017-02-21 v1.01   First cut of code
 // 2017-02-22 v1.02   Ensure we don't get debug messages
 // 2017-05-23 v1.03   Pass remote_addr/host info into build script
+// 2017-07-11 v1.04   Enable number of draws to be returned to be set in URL
 //
 
     set_include_path("/var/sites/s/shiny-ideas.tech/lib");
@@ -31,7 +32,11 @@
                     $json = array("status" => 9996, "msg" => "ERROR: INCORRECTTOKENSUPPLIED");
                 } else {
                     $debug = FALSE;
-                    $json  = buildJSON($_SERVER['REMOTE_ADDR']);
+                    $drawLimit = 50;
+                    if (isset($_GET["draws"])) {
+                        $drawLimit = $_GET["draws"];
+                    }
+                    $json  = buildJSON($_SERVER['REMOTE_ADDR'], $drawLimit);
                 }
             }
         }

--- a/sqllottery.php
+++ b/sqllottery.php
@@ -13,6 +13,7 @@
 // 2017-03-05 v0.05   Add is_bonus to lottery SQL
 // 2017-05-23 v0.06   Add insert SQL for remote logging table
 // 2017-05-26 v0.07   Renamed to sqllottery.php to prevent clash
+// 2017-07-11 v0.08   Added $limit as option in getDrawHistorySQL
 //
 
 function getLotteryDrawSQL() {
@@ -28,8 +29,12 @@ function getLotteryDrawSQL() {
     return $draws;
 }
 
-function getDrawHistorySQL($ident) {
-    return "SELECT draw, draw_date, last_modified FROM draw_history WHERE ident = ".$ident." order by draw DESC LIMIT 50";
+function getDrawHistorySQL($ident, $drawLimit) {
+    $sql = "SELECT draw, draw_date, last_modified FROM draw_history WHERE ident = ".$ident." order by draw DESC";
+    if (isset($drawLimit) && is_numeric($drawLimit)) {
+        $sql .= " LIMIT ".$drawLimit;
+    }
+    return $sql;
 }
 
 function getDigitSQL($ident, $draw, $isSpecial) {

--- a/staticJSONGenerator.php
+++ b/staticJSONGenerator.php
@@ -8,6 +8,7 @@
 // ========== ======= ====================================================
 // 2017-02-21 v1.01   First cut of code
 // 2017-02-21 v1.02   Include set_include_path directive
+// 2017-07-11 v1.03   Include LIMIT to draws extracted
 //
 
     set_include_path("<LIB GOES HERE>");
@@ -19,7 +20,7 @@
     $filename = "lotteryresults.json";
 
     $debug  = TRUE;
-    $output = buildJSON("localhost", "NONE");
+    $output = buildJSON("localhost", "NONE", 10);
     debugMessage("Writing JSON to file (".jsonFilename($wrksp, $filename).")...");
     if ($file = fopen(jsonFilename($wrksp, $filename), "w")) {
         fputs($file, $output);


### PR DESCRIPTION
1. Enabled calling URL to request the number of draws for the result
JSON
2. Added ‘draw_limit’ to JSON showing requested draw count (set to a
default of 50 if no value passed)